### PR TITLE
fix: copy TLS certs to dedicated directory for nginx container

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -42,6 +42,8 @@
       vars:
         step_ca_client_provisioner_password: "{{ lookup('aws_ssm', '/home-server/step-ca-ansible-password', region='eu-west-2') }}"
         step_ca_client_post_renew_commands:
+          - "cp /etc/ssl/certs/uptime-kuma.local.iamrobertyoung.co.uk.crt /etc/uptime-kuma/certs/"
+          - "cp /etc/ssl/private/uptime-kuma.local.iamrobertyoung.co.uk.pem /etc/uptime-kuma/certs/"
           - "docker kill -s HUP nginx"
         step_ca_client_cert_not_after: "168h"  # 7 days
 

--- a/roles/uptime-kuma/defaults/main.yml
+++ b/roles/uptime-kuma/defaults/main.yml
@@ -19,3 +19,5 @@ nginx_config_dir: /etc/nginx
 nginx_data_dir: /var/lib/nginx
 nginx_user: nginx
 nginx_service_name: nginx
+
+cert_dir: /etc/uptime-kuma/certs

--- a/roles/uptime-kuma/tasks/setup.yml
+++ b/roles/uptime-kuma/tasks/setup.yml
@@ -36,3 +36,28 @@
     - root
     - noxious
     - "{{ service_user }}"
+
+- name: Create cert directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ cert_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Copy TLS certificate
+  become: true
+  ansible.builtin.copy:
+    src: /etc/ssl/certs/{{ service_domain }}.crt
+    dest: "{{ cert_dir }}/{{ service_domain }}.crt"
+    remote_src: true
+    mode: "0644"
+  notify: "Restart {{ service_name }}"
+
+- name: Copy TLS private key
+  become: true
+  ansible.builtin.copy:
+    src: /etc/ssl/private/{{ service_domain }}.pem
+    dest: "{{ cert_dir }}/{{ service_domain }}.pem"
+    remote_src: true
+    mode: "0600"
+  notify: "Restart {{ service_name }}"

--- a/roles/uptime-kuma/templates/docker-compose/docker-compose.yml.j2
+++ b/roles/uptime-kuma/templates/docker-compose/docker-compose.yml.j2
@@ -20,8 +20,7 @@ services:
     volumes:
       - {{ nginx_config_dir }}:/etc/nginx
       - nginx-data:/data
-      - /etc/ssl/certs/uptime-kuma.{{ domain }}.crt:/etc/ssl/certs/uptime-kuma.{{ domain }}.crt:ro
-      - /etc/ssl/private/uptime-kuma.{{ domain }}.pem:/etc/ssl/private/uptime-kuma.{{ domain }}.pem:ro
+      - {{ cert_dir }}:/etc/nginx/certs:ro
     depends_on:
       - uptime-kuma
 

--- a/roles/uptime-kuma/templates/nginx/nginx.conf.j2
+++ b/roles/uptime-kuma/templates/nginx/nginx.conf.j2
@@ -84,8 +84,8 @@ http {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
     ssl_prefer_server_ciphers off;
-    ssl_certificate /etc/ssl/certs/{{ nginx_domain }}.crt;
-    ssl_certificate_key /etc/ssl/private/{{ nginx_domain }}.pem;
+    ssl_certificate /etc/nginx/certs/{{ nginx_domain }}.crt;
+    ssl_certificate_key /etc/nginx/certs/{{ nginx_domain }}.pem;
 
     location / {
       proxy_ssl_verify              off;


### PR DESCRIPTION
## Summary

- Copy TLS certs to `/etc/uptime-kuma/certs/` and mount directory instead of individual files, fixing cert renewal not being picked up by nginx container
- Add cert copy commands to step-ca-client post_renew hook so renewed certs are copied before nginx HUP
- Update nginx config to use `/etc/nginx/certs/` path inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)