### PR TITLE
chore: update step-ca-client role to v2.0.0

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -42,10 +42,9 @@
       vars:
         step_ca_client_provisioner_password: "{{ lookup('aws_ssm', '/home-server/step-ca-ansible-password', region='eu-west-2') }}"
         step_ca_client_post_renew_commands:
-          - "cp /etc/ssl/certs/uptime-kuma.local.iamrobertyoung.co.uk.crt /etc/uptime-kuma/certs/"
-          - "cp /etc/ssl/private/uptime-kuma.local.iamrobertyoung.co.uk.pem /etc/uptime-kuma/certs/"
+          - "cp /etc/ssl/certs/{{ fqdn }}.crt /etc/uptime-kuma/certs/"
+          - "cp /etc/ssl/private/{{ fqdn }}.pem /etc/uptime-kuma/certs/"
           - "docker kill -s HUP nginx"
-        step_ca_client_cert_not_after: "168h"  # 7 days
 
     - role: syslog
       tags: [syslog]

--- a/requirements.yml
+++ b/requirements.yml
@@ -26,7 +26,7 @@ roles:
 
   - src: git@github.com:RobertYoung/homelab-ansible-role-step-ca-client.git
     scm: git
-    version: v1.3.0
+    version: v2.0.0
     name: step-ca-client
 
   - src: git@github.com:RobertYoung/homelab-ansible-role-syslog.git

--- a/roles/uptime-kuma/tasks/setup.yml
+++ b/roles/uptime-kuma/tasks/setup.yml
@@ -43,21 +43,3 @@
     path: "{{ cert_dir }}"
     state: directory
     mode: "0755"
-
-- name: Copy TLS certificate
-  become: true
-  ansible.builtin.copy:
-    src: /etc/ssl/certs/{{ service_domain }}.crt
-    dest: "{{ cert_dir }}/{{ service_domain }}.crt"
-    remote_src: true
-    mode: "0644"
-  notify: "Restart {{ service_name }}"
-
-- name: Copy TLS private key
-  become: true
-  ansible.builtin.copy:
-    src: /etc/ssl/private/{{ service_domain }}.pem
-    dest: "{{ cert_dir }}/{{ service_domain }}.pem"
-    remote_src: true
-    mode: "0600"
-  notify: "Restart {{ service_name }}"


### PR DESCRIPTION
## Summary

- Upgrade step-ca-client role from v1.3.0 to v2.0.0
- Remove redundant cert copy tasks from uptime-kuma role, now handled by step-ca-client post-renew commands
- Use `fqdn` variable in post-renew commands for consistency and remove custom cert lifetime override

🤖 Generated with [Claude Code](https://claude.com/claude-code)