### PR TITLE
chore: update shell and step-ca-client roles

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -44,7 +44,7 @@
         step_ca_client_post_renew_commands:
           - "cp /etc/ssl/certs/{{ fqdn }}.crt /etc/uptime-kuma/certs/"
           - "cp /etc/ssl/private/{{ fqdn }}.pem /etc/uptime-kuma/certs/"
-          - "docker kill -s HUP nginx"
+          - "docker kill -s HUP nginx || echo 'Nginx not running, skipping HUP signal'"
 
     - role: syslog
       tags: [syslog]

--- a/requirements.yml
+++ b/requirements.yml
@@ -11,7 +11,7 @@ roles:
 
   - src: git@github.com:RobertYoung/homelab-ansible-role-shell.git
     scm: git
-    version: v1.3.0
+    version: v1.4.0
     name: shell
 
   - src: git@github.com:RobertYoung/homelab-ansible-role-docker.git
@@ -26,7 +26,7 @@ roles:
 
   - src: git@github.com:RobertYoung/homelab-ansible-role-step-ca-client.git
     scm: git
-    version: v2.0.0
+    version: v3.0.0
     name: step-ca-client
 
   - src: git@github.com:RobertYoung/homelab-ansible-role-syslog.git


### PR DESCRIPTION
## Summary

- Update shell role from v1.3.0 to v1.4.0
- Update step-ca-client role from v2.0.0 to v3.0.0 (major version bump)
- Make nginx HUP signal resilient when container isn't running during cert renewal

🤖 Generated with [Claude Code](https://claude.com/claude-code)