### PR TITLE
feat: migrate to Podman Quadlets and update SSM paths

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -34,13 +34,13 @@
         telegraf_influxdb_url: "https://influxdb.{{ domain }}"
         telegraf_influxdb_port: 8086
         telegraf_influxdb_organisation: "0dd8df669872ba9e"
-        telegraf_influxdb_token: "{{ lookup('aws_ssm', '/home-server/influxdb-token', region='eu-west-2') }}"
+        telegraf_influxdb_token: "{{ lookup('aws_ssm', '/homelab/influxdb/token', region='eu-west-1') }}"
         telegraf_influxdb_bucket: "home-server"
 
     - role: step-ca-client
       tags: [step-ca-client]
       vars:
-        step_ca_client_provisioner_password: "{{ lookup('aws_ssm', '/home-server/step-ca-ansible-password', region='eu-west-2') }}"
+        step_ca_client_provisioner_password: "{{ lookup('aws_ssm', '/homelab/step-ca/ansible-password', region='eu-west-1') }}"
         step_ca_client_post_renew_commands:
           - "mkdir -p /etc/uptime-kuma/certs"
           - "cp /etc/ssl/certs/{{ fqdn }}.crt /etc/uptime-kuma/certs/"
@@ -58,7 +58,7 @@
     - role: uptime-kuma
       tags: [uptime-kuma]
       vars:
-        backup_aws_access_key: "{{ lookup('aws_ssm', '/home-server/access-key', region='eu-west-2') }}"
-        backup_aws_secret_access_key: "{{ lookup('aws_ssm', '/home-server/secret-access-key', region='eu-west-2') }}"
+        backup_aws_access_key: "{{ lookup('aws_ssm', '/homelab/aws/access-key', region='eu-west-1') }}"
+        backup_aws_secret_access_key: "{{ lookup('aws_ssm', '/homelab/aws/secret-access-key', region='eu-west-1') }}"
         backup_aws_region: eu-west-2
-        backup_mosquitto_password: "{{ lookup('aws_ssm', '/home-server/mosquitto-home-assistant-password', region='eu-west-2') }}"
+        backup_mosquitto_password: "{{ lookup('aws_ssm', '/homelab/mosquitto/home-assistant-password', region='eu-west-1') }}"


### PR DESCRIPTION
## Summary

- Replace Docker Compose with Podman Quadlets for container management (uptime-kuma, traefik, backup-toolkit), aligning with the homelab-jellyfin project conventions
- Swap the `docker` role for a new `podman` role and convert systemd unit/handler wiring accordingly
- Migrate SSM parameter lookups from `/home-server/*` (eu-west-2) to the current `/homelab/*` structure in eu-west-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)